### PR TITLE
Do not link against libasan

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,8 @@ impl Build {
 
             //configure.arg("enable-asan"); // If compiled with clang this implies "-static-libasan"
             cc.push_str(" -fsanitize=address -shared-libsan");
-            println!("cargo:rustc-link-lib=asan");
+            println!("cargo:rustc-link-arg=-fsanitize=address"); // TODO are these used during the final link step?
+            println!("cargo:rustc-link-arg=-shared-libasan"); // TODO are these used during the final link step?
         }
 
         configure.env("CC", cc);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,9 +520,8 @@ impl Build {
             configure.arg("-DOPENSSL_NO_BUF_FREELISTS");
 
             //configure.arg("enable-asan"); // If compiled with clang this implies "-static-libasan"
+            // Important: Make sure to pass these flags to the linker invoked by rustc!
             cc.push_str(" -fsanitize=address -shared-libsan");
-            println!("cargo:rustc-link-arg=-fsanitize=address"); // TODO are these used during the final link step?
-            println!("cargo:rustc-link-arg=-shared-libasan"); // TODO are these used during the final link step?
         }
 
         configure.env("CC", cc);


### PR DESCRIPTION
libasan is from GCC and not from LLVM. Also always use -fsanitize=address instead of linking manually.
The -f flag makes sure that the correct symbols end up in the final binary.